### PR TITLE
ecrsecret: break out a comma-separated set object

### DIFF
--- a/pkg/csset/csset.go
+++ b/pkg/csset/csset.go
@@ -1,0 +1,61 @@
+package csset
+
+import (
+	"strings"
+	"sync"
+)
+
+// CSSet is a comma-separated set of strings.
+type CSSet struct {
+	mu  sync.Mutex
+	set map[string]struct{}
+}
+
+func NewCSSet(s string) *CSSet {
+	c := &CSSet{
+		set: make(map[string]struct{}),
+	}
+	if s == "" {
+		return c
+	}
+
+	for _, value := range strings.Split(s, ",") {
+		c.Add(value)
+	}
+	return c
+}
+
+func (c *CSSet) Add(value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.set[value] = struct{}{}
+}
+
+func (c *CSSet) Del(value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.set, value)
+}
+
+func (c *CSSet) Has(value string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, found := c.set[value]
+	return found
+}
+
+func (c *CSSet) Size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.set)
+}
+
+func (c *CSSet) String() string {
+	out := []string{}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.set {
+		out = append(out, key)
+	}
+	return strings.Join(out, ",")
+}

--- a/pkg/csset/csset_test.go
+++ b/pkg/csset/csset_test.go
@@ -1,0 +1,61 @@
+package csset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCSSetEmptyInit(t *testing.T) {
+	set := NewCSSet("")
+	assert.Equal(t, "", set.String())
+}
+
+func TestCSSetContentsInit(t *testing.T) {
+	set := NewCSSet("one,three,two")
+	n := struct{}{}
+	assert.ObjectsAreEqual(map[string]struct{}{
+		"one": n, "two": n, "three": n},
+		set.set)
+}
+
+func TestCSSetAdd(t *testing.T) {
+	set := NewCSSet("")
+	set.Add("one")
+	assert.Equal(t, "one", set.String())
+}
+
+func TestCSSetTwo(t *testing.T) {
+	set := NewCSSet("")
+	set.Add("one")
+	set.Add("two")
+	assert.Equal(t, "one,two", set.String())
+}
+
+func TestCSSetDel(t *testing.T) {
+	set := NewCSSet("one,two")
+	set.Del("one")
+	assert.Equal(t, "two", set.String())
+}
+
+func TestCSSetHas(t *testing.T) {
+	set := NewCSSet("one,two")
+	assert.True(t, set.Has("one"))
+	assert.True(t, set.Has("two"))
+	assert.False(t, set.Has("three"))
+}
+
+func TestCSSetDelNotExists(t *testing.T) {
+	set := NewCSSet("one,two")
+	assert.NotPanics(t, func() { set.Del("three") })
+}
+
+func TestCSSetLenZero(t *testing.T) {
+	set := NewCSSet("")
+	assert.Zero(t, set.Size())
+}
+
+func TestCSSetLenTwo(t *testing.T) {
+	set := NewCSSet("one,two")
+	assert.Equal(t, 2, set.Size())
+}


### PR DESCRIPTION
This object is a handy little set implementation that makes working with a set
that's expressed as comma-separated values.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
